### PR TITLE
Fix accellera-official/fc4sc#20

### DIFF
--- a/examples/fir/src/display.cpp
+++ b/examples/fir/src/display.cpp
@@ -70,7 +70,7 @@ void display::entry(){
 	 << " at time " << sc_time_stamp().to_double() << endl;
     
     // generate the coverage database from the collected data
-    fc4sc::global::coverage_save("coverage_results.xml");    
+    xml_printer::coverage_save("coverage_results.xml");
     sc_stop();
   };
 }

--- a/includes/fc4sc_coverpoint.hpp
+++ b/includes/fc4sc_coverpoint.hpp
@@ -570,11 +570,7 @@ public:
 	}
         catch(illegal_bin_sample_exception &e) {
           e.update_cvp_info(this->name());
-          std::cerr << e.what() << std::endl;
-#ifndef FC4SC_NO_THROW // By default the simulation will stop
-          std::cerr << "Stopping simulation\n";
 	  throw(e);
-#endif
         }
       }
       else {


### PR DESCRIPTION
Fixes #20.
Also fixes compilation error for the **examples/fir** due to change in API for saving the coverage database from **fc4sc::global::coverage_save** to **xml_printer::coverage_save**.